### PR TITLE
Fix undefined variables in docs

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/Makefile
+++ b/{{cookiecutter.repo_name}}/docs/Makefile
@@ -77,17 +77,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/{{ project_name }}.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/{{ cookiecutter.project_name }}.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/{{ project_name }}.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/{{ cookiecutter.project_name }}.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/{{ project_name }}"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/{{ project_name }}"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/{{ cookiecutter.project_name }}"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/{{ cookiecutter.project_name }}"
 	@echo "# devhelp"
 
 epub:

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# {{ project_name }} documentation build configuration file, created by
+# {{ cookiecutter.project_name }} documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 17 11:46:20 2013.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'{{ project_name }}'
-copyright = u'{{ year }}, {{ author_name }}'
+project = u'{{ cookiecutter.project_name }}'
+copyright = u'{{ cookiecutter.year }}, {{ cookiecutter.author_name }}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -164,7 +164,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '{{ project_name }}doc'
+htmlhelp_basename = '{{ cookiecutter.project_name }}doc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -183,8 +183,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', '{{ project_name }}.tex', u'{{ project_name }} Documentation',
-   u'{{ author_name }}', 'manual'),
+  ('index', '{{ cookiecutter.project_name }}.tex', u'{{ cookiecutter.project_name }} Documentation',
+   u'{{ cookiecutter.author_name }}', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -213,8 +213,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', '{{ project_name }}', u'{{ project_name }} Documentation',
-     [u'{{ author_name }}'], 1)
+    ('index', '{{ cookiecutter.project_name }}', u'{{ cookiecutter.project_name }} Documentation',
+     [u'{{ cookiecutter.author_name }}'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -227,8 +227,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', '{{ project_name }}', u'{{ project_name }} Documentation',
-   u'{{ author_name }}', '{{ project_name }}', 'One line description of project.',
+  ('index', '{{ cookiecutter.project_name }}', u'{{ cookiecutter.project_name }} Documentation',
+   u'{{ cookiecutter.author_name }}', '{{ cookiecutter.project_name }}', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/{{cookiecutter.repo_name}}/docs/index.rst
+++ b/{{cookiecutter.repo_name}}/docs/index.rst
@@ -1,9 +1,9 @@
-.. {{ project_name }} documentation master file, created by
+.. {{ cookiecutter.project_name }} documentation master file, created by
    sphinx-quickstart on Sun Feb 17 11:46:20 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to {{ project_name }}'s documentation!
+Welcome to {{ cookiecutter.project_name }}'s documentation!
 ==============================================
 
 Contents:

--- a/{{cookiecutter.repo_name}}/docs/make.bat
+++ b/{{cookiecutter.repo_name}}/docs/make.bat
@@ -99,9 +99,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\{{ project_name }}.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\{{ cookiecutter.project_name }}.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\{{ project_name }}.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\{{ cookiecutter.project_name }}.ghc
 	goto end
 )
 


### PR DESCRIPTION
As of version [1.4.0](http://cookiecutter.readthedocs.org/en/latest/history.html#shortbread) of cookiecutter, undefined variables throw an error. I was trying to use this today and kept running into it unable to create my project's layout.

Turns out that variables in the docs directory where being used like this `{{ project_name }}`

And should have been like this: `{{ cookiecutter.project_name }}`

This pull request fixes that issue making this work with cookiecutter 1.4.0.

Hope it helps, keep up the good work!