### PR TITLE
option to use sqlite3 in local enviroment

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,7 @@
     "email": "Your email",
     "description": "A short description of the project.",
     "year": "Current year",
+    "use_sqlite_as_local_db_engine": "no",
     "with_documentation": "yes"
+
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/local.py
@@ -8,13 +8,15 @@ ADMINS = (
 MANAGERS = ADMINS
 
 DATABASES = {
-    'default': {
+    'default': { {% if cookiecutter.use_sqlite_as_local_db_engine == 'yes' %}
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': '{{cookiecutter.repo_name}}.db',{% else %}
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': '{{cookiecutter.repo_name}}',
         'USER': 'postgres',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': '',
+        'PORT': '',{% endif %}
     }
 }
 


### PR DESCRIPTION
most of the time I just need a ready to go config based on sqlite3, as the standard django-admin's `startproject` command creates.
