### PR TITLE
fixed TEMPLATES reference in settings/production.py

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -3,7 +3,7 @@ import os
 
 
 DEBUG = False
-TEMPLATES['OPTIONS']['debug'] = DEBUG
+TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 SECRET_KEY = os.environ["SECRET_KEY"]
 


### PR DESCRIPTION
  File "some_path/settings/production.py", line 6, in <module>
    TEMPLATES['OPTIONS']['debug'] = DEBUG
TypeError: list indices must be integers or slices, not str